### PR TITLE
Please use releases instead of the dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.0",
         "dreipunktnull/dhl-shipment-tracking": "dev-master",
         "symfony/symfony": "^3.3",
-        "petschko/dhl-php-sdk": "dev-master"
+        "petschko/dhl-php-sdk": "^0.3"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
I would sleep better, when you use releases instead of my master branch. The idea is, when I do some stuff and there is a bug you would not be affected, since you use releases...

I hope I done this right (was unsure if I need to specify the version with `^v0.3` or `^0.3`, since I tag my Versions with the `v` prefix...